### PR TITLE
Adding in Code Engine and VPC MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ MCP is an open-source protocol designed to enable AI models to securely interact
 - [IBM Cloud MCP Server](https://ibm-cloud.github.io/mcp/) - Enhance your LLM with tools from IBM Cloud.
 - [IBM Storage Insights MCP Server](https://github.com/IBM/ibm-storageinsights-mcpserver) - Leverage key IBM Storage Insights monitoring capabilities via an MCP interface.
 - [IBM watsonx.data Document Retrieval MCP Server](https://github.com/IBM/ibm-watsonxdata-dl-retrieval-mcp-server) - Query document libraries from watsonx.data using conversational language and receive human-readable responses.
+- [IBM Cloud VPC MCP Server](https://github.com/greyhoundforty/code-engine-mcp) - Provides access to IBM Cloud VPC resources and security analysis capabilities, enabling AI agents to interact with cloud infrastructure, backups, and security policies. 
+- [IBM Cloud Code Engine MCP Server](https://github.com/greyhoundforty/code-engine-mcp) - This MCP server provides tools to list and inspect Code Engine projects, applications, revisions, domain mappings, and secrets. 
 
 #### Hashicorp
 


### PR DESCRIPTION
Let me know if these need to move to another org or repo. Code Engine one is up to date as of this PR and the VPC one is functional, just needs to be extended a bit. 