### PR TITLE
feat: add TIM MCP server to documentation and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ MCP is an open-source protocol designed to enable AI models to securely interact
 | Server name | Description | Usage |
 |---|---|---|
 | [IBM Cloud MCP Server](https://ibm-cloud.github.io/mcp/) | Enhance your LLM with tools from IBM Cloud. | *see link for instructions* |
+| [Terraform IBM Modules (TIM) MCP Server](https://github.com/terraform-ibm-modules/tim-mcp) | The TIM-MCP server provides structured access to the Terraform IBM Modules(TIM) ecosystem, enabling intelligent provisioning of IBM Cloud infrastructure resources as code. | *see link for instructions* |
 | [IBM Cloud Code Engine MCP Server](https://github.com/greyhoundforty/code-engine-mcp) | This MCP server provides tools to list and inspect Code Engine projects, applications, revisions, domain mappings, and secrets. | *see link for instructions* |
 | [IBM Cloud VPC MCP Server](https://github.com/greyhoundforty/ibmcloud-vpc-mcp) | Provides access to IBM Cloud VPC resources and security analysis capabilities, enabling AI agents to interact with cloud infrastructure, backups, and security policies. | *see link for instructions* |
 | [IBM Power Virtual Server MCP Server](https://github.com/IBM/powervs-mcp-server) | Brings to AI-Agents seamless observability and diagnosis of their virtual machines registered with IBM Power Virtual Server  | *see link for instructions* |

--- a/mcp.json
+++ b/mcp.json
@@ -49,6 +49,17 @@
       "type": "http"
     },
     "ibmcloud-mcp-server": {},
+    "tim-mcp-server": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/terraform-ibm-modules/tim-mcp.git",
+        "tim-mcp"
+      ],
+      "env": {
+        "GITHUB_TOKEN": "<your_github_token>"
+      }
+    },
     "ibmcloud-code-engine-mcp-server": {},
     "ibmcloud-vpc-mcp-server": {},
     "terraform-mcp-server": {


### PR DESCRIPTION
This PR adds the Offical Terraform IBM Modules (TIM) MCP server. The TIM-MCP server provides structured access to the Terraform IBM Modules ecosystem, enabling intelligent provisioning of IBM Cloud infrastructure resources as code.

https://github.com/terraform-ibm-modules/tim-mcp